### PR TITLE
pretty print main output to match readme output

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,11 +49,20 @@ func main() {
 
 	json.Unmarshal([]byte(j_string_map), &empty)
 
-	fmt.Printf("empty: %+v\n", empty)
+	// Not Flattened example
+	fmt.Printf("\nNot Flattened\n------------\n\n")
+	a, err := json.MarshalIndent(empty, "", "  ")
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(a))
 
+	// Flattened example
+	fmt.Printf("\nFlattened\n---------\n\n")
 	f := flattened.Flatten("", empty)
-	fmt.Println(f)
-
-	f_string, _ := json.Marshal(f)
-	fmt.Println(string(f_string))
+	b, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(b))
 }


### PR DESCRIPTION
- Main.go printed the map flattened as you intended, but it was still difficult to parse. 
- In this PR, main.go now mirrors what you have displayed in your README. 
- The screenshot below shows a before and after for comparison.

<img width="909" alt="pretty-print-example-comparison" src="https://user-images.githubusercontent.com/17617685/66190473-11b48880-e65a-11e9-84a8-6344c9106c5c.png">
